### PR TITLE
Follow libXp removal, remove include buildlink3.mk of libXp

### DIFF
--- a/openjdk10/options.mk
+++ b/openjdk10/options.mk
@@ -24,8 +24,6 @@ CONFIGURE_ARGS+=	--enable-headful
 DEPENDS+=		dejavu-ttf-[0-9]*:../../fonts/dejavu-ttf
 .include "../../x11/libXext/buildlink3.mk"
 .include "../../x11/libXi/buildlink3.mk"
-BUILDLINK_DEPMETHOD.libXp?=	build
-.include "../../x11/libXp/buildlink3.mk"
 BUILDLINK_DEPMETHOD.libXt?=	build
 .include "../../x11/libXt/buildlink3.mk"
 .include "../../x11/libXtst/buildlink3.mk"

--- a/openjdk11/options.mk
+++ b/openjdk11/options.mk
@@ -23,8 +23,6 @@ CONFIGURE_ARGS+=	--x-libraries=${X11BASE}/lib
 DEPENDS+=		dejavu-ttf-[0-9]*:../../fonts/dejavu-ttf
 .include "../../x11/libXext/buildlink3.mk"
 .include "../../x11/libXi/buildlink3.mk"
-BUILDLINK_DEPMETHOD.libXp?=	build
-.include "../../x11/libXp/buildlink3.mk"
 BUILDLINK_DEPMETHOD.libXt?=	build
 .include "../../x11/libXt/buildlink3.mk"
 .include "../../x11/libXtst/buildlink3.mk"

--- a/openjdk7/Makefile
+++ b/openjdk7/Makefile
@@ -272,8 +272,6 @@ BUILDLINK_DEPMETHOD.cups?=	build
 .include "../../print/cups/buildlink3.mk"
 .include "../../x11/libXext/buildlink3.mk"
 .include "../../x11/libXi/buildlink3.mk"
-BUILDLINK_DEPMETHOD.libXp?=	build
-.include "../../x11/libXp/buildlink3.mk"
 BUILDLINK_DEPMETHOD.libXt?=	build
 .include "../../x11/libXt/buildlink3.mk"
 .include "../../x11/libXtst/buildlink3.mk"

--- a/openjdk9/options.mk
+++ b/openjdk9/options.mk
@@ -24,8 +24,6 @@ CONFIGURE_ARGS+=	--enable-headful
 DEPENDS+=		dejavu-ttf-[0-9]*:../../fonts/dejavu-ttf
 .include "../../x11/libXext/buildlink3.mk"
 .include "../../x11/libXi/buildlink3.mk"
-BUILDLINK_DEPMETHOD.libXp?=	build
-.include "../../x11/libXp/buildlink3.mk"
 BUILDLINK_DEPMETHOD.libXt?=	build
 .include "../../x11/libXt/buildlink3.mk"
 .include "../../x11/libXtst/buildlink3.mk"


### PR DESCRIPTION
Like lang/openjdk8, remove dependencies.
And x11/libXp is removed in March, 2019.