### PR TITLE
Fixed Percona XTraDB Cluster pulling in wrong dependency

### DIFF
--- a/percona80-cluster/Makefile
+++ b/percona80-cluster/Makefile
@@ -19,7 +19,7 @@ DEPENDS+=	coreutils>=0:../../sysutils/coreutils	# GNU mktemp
 DEPENDS+=	findutils>=0:../../sysutils/findutils	# find -regex
 DEPENDS+=	grep>=0:../../textproc/grep		# grep -o
 DEPENDS+=	socat>=0:../../net/socat
-DEPENDS+=	percona-xtrabackup>=8:../../joyent/percona80-xtrabackup
+DEPENDS+=	percona-xtrabackup>=8<8.1:../../joyent/percona80-xtrabackup
 
 # nbpatch fails
 BUILD_DEPENDS+=	patch-[0-9]*:../../devel/patch


### PR DESCRIPTION
Version 8.4 of the percona-xtrabackup package was being pulled in, while Percona XTraDB 8.0 can only work with percona-xtrabackup version 8.0.

I've tested this fix by building and deploying the modified package to our internal pkgsrc repo and then installing Percona XTraDB cluster.